### PR TITLE
Update python_version for 3.13

### DIFF
--- a/awscloudtrail.json
+++ b/awscloudtrail.json
@@ -8,7 +8,7 @@
     "logo_dark": "logo_aws_dark.svg",
     "product_name": "CloudTrail",
     "product_version_regex": ".*",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "publisher": "Splunk",
     "license": "Copyright (c) 2019-2024 Splunk Inc.",
     "app_version": "2.2.8",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions-3.13`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions-3.13)